### PR TITLE
Fixed setChildren(List<TreeNode> children) method

### DIFF
--- a/treeview_lib/src/main/java/me/texy/treeview/TreeNode.java
+++ b/treeview_lib/src/main/java/me/texy/treeview/TreeNode.java
@@ -119,10 +119,16 @@ public class TreeNode {
         }
         return selectedChildren;
     }
-
+    
     public void setChildren(List<TreeNode> children) {
-        this.children = children;
-    }
+        if (children == null) {
+            return;
+        }        
+        this.children = new ArrayList<>();
+        for (TreeNode child : children) {
+            addChild(child);
+        }
+    }    
 
     public void setExpanded(boolean expanded) {
         this.expanded = expanded;


### PR DESCRIPTION
- Fixed fatal exception: java.lang.NullPointerException: Attempt to invoke virtual method 'java.util.List me.texy.treeview.TreeNode.getChildren()' on a null object reference.
- Fixed a bug where the Index is always 0

These problems occurred because the setChildren(List\<TreeNode\> children) method did not initialize the Index and Parent of each child element.