### PR TITLE
Improvement of the demo code to show how you can avoid showing the arrow when there are no children.

### DIFF
--- a/app/src/main/java/me/texy/treeviewdemo/FirstLevelNodeViewBinder.java
+++ b/app/src/main/java/me/texy/treeviewdemo/FirstLevelNodeViewBinder.java
@@ -35,6 +35,7 @@ public class FirstLevelNodeViewBinder extends CheckableNodeViewBinder {
     public void bindView(final TreeNode treeNode) {
         textView.setText(treeNode.getValue().toString());
         imageView.setRotation(treeNode.isExpanded() ? 90 : 0);
+        imageView.setVisibility(treeNode.hasChild() ? View.VISIBLE : View.INVISIBLE);
     }
 
     @Override

--- a/app/src/main/java/me/texy/treeviewdemo/MainActivity.java
+++ b/app/src/main/java/me/texy/treeviewdemo/MainActivity.java
@@ -95,10 +95,15 @@ public class MainActivity extends AppCompatActivity {
             for (int j = 0; j < 10; j++) {
                 TreeNode treeNode1 = new TreeNode(new String("Child " + "No." + j));
                 treeNode1.setLevel(1);
+                if(j < 9) { // avoids creating grand child nodes for the last child node
+                // For the last child node without grand children there should not be any arrow displayed.
+                // But currently it causes problem if not having the same number of levels for all child nodes
+                // i.e. the nodes without any child nodes will currently still show an arrow as if there were child nodes.
                 for (int k = 0; k < 5; k++) {
                     TreeNode treeNode2 = new TreeNode(new String("Grand Child " + "No." + k));
                     treeNode2.setLevel(2);
                     treeNode1.addChild(treeNode2);
+                }
                 }
                 treeNode.addChild(treeNode1);
             }

--- a/app/src/main/java/me/texy/treeviewdemo/MainActivity.java
+++ b/app/src/main/java/me/texy/treeviewdemo/MainActivity.java
@@ -93,21 +93,21 @@ public class MainActivity extends AppCompatActivity {
             TreeNode treeNode = new TreeNode(new String("Parent  " + "No." + i));
             treeNode.setLevel(0);
             if(i < 19) { // avoids creating child nodes for the last parent node
-            for (int j = 0; j < 10; j++) {
-                TreeNode treeNode1 = new TreeNode(new String("Child " + "No." + j));
-                treeNode1.setLevel(1);
-                if(j < 9) { // avoids creating grand child nodes for the last child node
-                    // For the last child node without grand children there should not be any arrow displayed.
-                    // In the demo code this can be handled in method 'SecondLevelNodeViewBinder.bindView' like this:
-                    // imageView.setVisibility(treeNode.hasChild() ? View.VISIBLE : View.INVISIBLE);
-                    for (int k = 0; k < 5; k++) {
-                        TreeNode treeNode2 = new TreeNode(new String("Grand Child " + "No." + k));
-                        treeNode2.setLevel(2);
-                        treeNode1.addChild(treeNode2);
+                for (int j = 0; j < 10; j++) {
+                    TreeNode treeNode1 = new TreeNode(new String("Child " + "No." + j));
+                    treeNode1.setLevel(1);
+                    if(j < 9) { // avoids creating grand child nodes for the last child node
+                        // For the last child node without grand children there should not be any arrow displayed.
+                        // In the demo code this can be handled in method 'SecondLevelNodeViewBinder.bindView' like this:
+                        // imageView.setVisibility(treeNode.hasChild() ? View.VISIBLE : View.INVISIBLE);
+                        for (int k = 0; k < 5; k++) {
+                            TreeNode treeNode2 = new TreeNode(new String("Grand Child " + "No." + k));
+                            treeNode2.setLevel(2);
+                            treeNode1.addChild(treeNode2);
+                        }
                     }
+                    treeNode.addChild(treeNode1);
                 }
-                treeNode.addChild(treeNode1);
-            }
             }
             root.addChild(treeNode);
         }

--- a/app/src/main/java/me/texy/treeviewdemo/MainActivity.java
+++ b/app/src/main/java/me/texy/treeviewdemo/MainActivity.java
@@ -92,13 +92,14 @@ public class MainActivity extends AppCompatActivity {
         for (int i = 0; i < 20; i++) {
             TreeNode treeNode = new TreeNode(new String("Parent  " + "No." + i));
             treeNode.setLevel(0);
+            if(i < 19) { // avoids creating child nodes for the last parent node
             for (int j = 0; j < 10; j++) {
                 TreeNode treeNode1 = new TreeNode(new String("Child " + "No." + j));
                 treeNode1.setLevel(1);
                 if(j < 9) { // avoids creating grand child nodes for the last child node
                     // For the last child node without grand children there should not be any arrow displayed.
-                    // But currently it causes problem if not having the same number of levels for all child nodes
-                    // i.e. the nodes without any child nodes will currently still show an arrow as if there were child nodes.
+                    // In the demo code this can be handled in method 'SecondLevelNodeViewBinder.bindView' like this:
+                    // imageView.setVisibility(treeNode.hasChild() ? View.VISIBLE : View.INVISIBLE);
                     for (int k = 0; k < 5; k++) {
                         TreeNode treeNode2 = new TreeNode(new String("Grand Child " + "No." + k));
                         treeNode2.setLevel(2);
@@ -106,6 +107,7 @@ public class MainActivity extends AppCompatActivity {
                     }
                 }
                 treeNode.addChild(treeNode1);
+            }
             }
             root.addChild(treeNode);
         }

--- a/app/src/main/java/me/texy/treeviewdemo/MainActivity.java
+++ b/app/src/main/java/me/texy/treeviewdemo/MainActivity.java
@@ -92,12 +92,12 @@ public class MainActivity extends AppCompatActivity {
         for (int i = 0; i < 20; i++) {
             TreeNode treeNode = new TreeNode(new String("Parent  " + "No." + i));
             treeNode.setLevel(0);
-            if(i < 19) { // avoids creating child nodes for the last parent node
+            if(i != 3) { // avoids creating child nodes for "parent" 3 (which then is not a parent, so the semantic in the displayed text becomes incorrect)
                 for (int j = 0; j < 10; j++) {
                     TreeNode treeNode1 = new TreeNode(new String("Child " + "No." + j));
                     treeNode1.setLevel(1);
-                    if(j < 9) { // avoids creating grand child nodes for the last child node
-                        // For the last child node without grand children there should not be any arrow displayed.
+                    if(j != 5) { // avoids creating grand child nodes for child node 5
+                        // For the child node without grand children there should not be any arrow displayed.
                         // In the demo code this can be handled in method 'SecondLevelNodeViewBinder.bindView' like this:
                         // imageView.setVisibility(treeNode.hasChild() ? View.VISIBLE : View.INVISIBLE);
                         for (int k = 0; k < 5; k++) {

--- a/app/src/main/java/me/texy/treeviewdemo/MainActivity.java
+++ b/app/src/main/java/me/texy/treeviewdemo/MainActivity.java
@@ -96,14 +96,14 @@ public class MainActivity extends AppCompatActivity {
                 TreeNode treeNode1 = new TreeNode(new String("Child " + "No." + j));
                 treeNode1.setLevel(1);
                 if(j < 9) { // avoids creating grand child nodes for the last child node
-                // For the last child node without grand children there should not be any arrow displayed.
-                // But currently it causes problem if not having the same number of levels for all child nodes
-                // i.e. the nodes without any child nodes will currently still show an arrow as if there were child nodes.
-                for (int k = 0; k < 5; k++) {
-                    TreeNode treeNode2 = new TreeNode(new String("Grand Child " + "No." + k));
-                    treeNode2.setLevel(2);
-                    treeNode1.addChild(treeNode2);
-                }
+                    // For the last child node without grand children there should not be any arrow displayed.
+                    // But currently it causes problem if not having the same number of levels for all child nodes
+                    // i.e. the nodes without any child nodes will currently still show an arrow as if there were child nodes.
+                    for (int k = 0; k < 5; k++) {
+                        TreeNode treeNode2 = new TreeNode(new String("Grand Child " + "No." + k));
+                        treeNode2.setLevel(2);
+                        treeNode1.addChild(treeNode2);
+                    }
                 }
                 treeNode.addChild(treeNode1);
             }

--- a/app/src/main/java/me/texy/treeviewdemo/SecondLevelNodeViewBinder.java
+++ b/app/src/main/java/me/texy/treeviewdemo/SecondLevelNodeViewBinder.java
@@ -36,6 +36,7 @@ public class SecondLevelNodeViewBinder extends CheckableNodeViewBinder {
     public void bindView(final TreeNode treeNode) {
         textView.setText(treeNode.getValue().toString());
         imageView.setRotation(treeNode.isExpanded() ? 90 : 0);
+        imageView.setVisibility(treeNode.hasChild() ? View.VISIBLE : View.INVISIBLE);
     }
 
     @Override


### PR DESCRIPTION
Improvement of the demo code to show how you can avoid showing the arrow when there are no children for a node.

The demo code (in the current master branch) assumes that all parent and child nodes have child and grand child nodes i.e. always show an arrow.
If for example (as in the pull request code) modifying the construction of nodes in such a way that "parent" 3 has no children and that child 5 has no grand children then it looks like in the picture below (after having clicked parent 3 and child 5, and also clicked some others):
![without_fix_screenshot](https://user-images.githubusercontent.com/1504507/63519621-8fca2f00-c4f3-11e9-9a9f-3a8583a0da2e.jpg)

Note in the picture above that the arrow for parent 3 has been rotated (even though there are no children) and the same thing for child 5.

This situation can be handled in the CheckableNodeViewBinder subclasses like this (as in the pull request code):
`imageView.setVisibility(treeNode.hasChild() ? View.VISIBLE : View.INVISIBLE);`

Then the result looks like blow i.e. no misleading arrow image indicating that there would be children:
![with_fix_screenshot](https://user-images.githubusercontent.com/1504507/63519577-8771f400-c4f3-11e9-9c8a-2efdc8169b28.jpg)

