### PR TITLE
Adding an overridable method BaseNodeViewFactory.getViewType with default implementation returning the tree node level

### DIFF
--- a/treeview_lib/src/main/java/me/texy/treeview/TreeViewAdapter.java
+++ b/treeview_lib/src/main/java/me/texy/treeview/TreeViewAdapter.java
@@ -83,7 +83,10 @@ public class TreeViewAdapter extends RecyclerView.Adapter {
 
     @Override
     public int getItemViewType(int position) {
-        return expandedNodeList.get(position).getLevel();
+        // return expandedNodeList.get(position).getLevel(); // this old code row used to always return the level
+        TreeNode treeNode = expandedNodeList.get(position);
+        int viewType = this.baseNodeViewFactory.getViewType(treeNode); // default implementation returns the three node level but it can be overridden
+        return viewType;
     }
 
     @NonNull

--- a/treeview_lib/src/main/java/me/texy/treeview/base/BaseNodeViewFactory.java
+++ b/treeview_lib/src/main/java/me/texy/treeview/base/BaseNodeViewFactory.java
@@ -16,6 +16,8 @@ package me.texy.treeview.base;
 
 import android.view.View;
 
+import me.texy.treeview.TreeNode;
+
 /**
  * Created by zxy on 17/4/23.
  */
@@ -23,13 +25,23 @@ import android.view.View;
 public abstract class BaseNodeViewFactory {
 
     /**
+    * The default implementation below behaves as in previous version when TreeViewAdapter.getItemViewType always returned the level,
+    * but you can override it if you want some other viewType value to become the parameter to the method getNodeViewBinder.
+    * @param treeNode
+    * @return
+    */
+    public int getViewType(TreeNode treeNode) {
+        return treeNode.getLevel();
+    }
+
+    /**
      * If you want build a tree view,you must implement this factory method
      *
      * @param view  The parameter for BaseNodeViewBinder's constructor, do not use this for other
      *              purpose!
-     * @param level The treeNode level
+     * @param viewType The viewType value is the treeNode level in the default implementation.
      * @return BaseNodeViewBinder
      */
-    public abstract BaseNodeViewBinder getNodeViewBinder(View view, int level);
+    public abstract BaseNodeViewBinder getNodeViewBinder(View view, int viewType);
 
 }


### PR DESCRIPTION
The method TreeViewAdapter.getItemViewType then uses BaseNodeViewFactory.getViewType instead of always having to return the tree node level.
Then the client code can use something else than the tree node level for selecting the Binder and its layout file.

See also issue 25 when this kind of feature was requested.
https://github.com/shineM/TreeView/issues/25

Screenshot for a sample app where all items are displayed with the same binder and layout file 
EXCEPT for one specific binder and layout file for Stockholm, i.e. the yellow item in the screenshot below.
![sample_with_geographic_areas_getViewType](https://user-images.githubusercontent.com/1504507/63587186-8dbfa900-c5a3-11e9-95c0-c0ca39503ac0.jpg)


Here is the code using the getViewType method in the sample app for the above screnshot:
https://github.com/TomasJohansson/TreeView/commit/699291713416b624ef45919ad3eb34161fcd133c#diff-effcb19dc75b5646f230694a17d35433